### PR TITLE
Add how votes are calculated on Metaforo to the Amendment

### DIFF
--- a/rules-cn.md
+++ b/rules-cn.md
@@ -102,4 +102,4 @@ DAO 支持两种类型的治理：
 ## 修正案
 
 - [禁止向 DAO 的投票者空投任何资产](https://dao.ckb.community/thread/vot-ban-incentivized-voting-in-dao-43212)。
-
+- [Metaforo 上的票数根据投票者当前持有的 Nervos DAO 存款值计算，已解锁/提现的 CKB 不计入投票权重](https://dao.ckb.community/thread/vot-changing-how-votes-are-calculated-43287)。

--- a/rules-en.md
+++ b/rules-en.md
@@ -104,3 +104,4 @@ After the proposal is passed, it will enter the Execution Stage.
 ## Amendment
 
 - [Any airdropping of assets to DAO voters is prohibited.](https://dao.ckb.community/thread/vot-ban-incentivized-voting-in-dao-43212) 
+- [On Metaforo, votes are calculated based on the current Nervos DAO deposits held by the voters. Unlocked or withdrawn CKB will not be counted towards the voting weight](https://dao.ckb.community/thread/vot-changing-how-votes-are-calculated-43287).


### PR DESCRIPTION
根据提案《[[VOT] 修改票数的计算方式 / Changing How Votes Are Calculated](https://dao.ckb.community/thread/vot-changing-how-votes-are-calculated-43287)》的投票结果，在 “修正案” 一栏中新增了一条规则："Metaforo 上的票数根据投票者当前持有的 Nervos DAO 存款值计算，已解锁/提现的 CKB 不计入投票权重。"

---

The rules of CKB Community Fund DAO were amended to include “On Metaforo, votes are calculated based on the current Nervos DAO deposits held by the voters. Unlocked or withdrawn CKB will not be counted towards the voting weight.” in the “Amendment” column in accordance with the proposal [[VOT] 修改票数的计算方式 / Changing How Votes Are Calculated](https://dao.ckb.community/thread/vot-changing-how-votes-are-calculated-43287)